### PR TITLE
Update package dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 http://zlib.net/zlib-1.2.11.tar.gz
-http://sourceforge.net/projects/arma/files/armadillo-8.400.0.tar.xz -DBUILD_SHARED_LIBS=OFF
-statgen/libStatGen@v1.0.14 --cmake dep/libstatgen.cmake
+http://sourceforge.net/projects/arma/files/armadillo-8.600.1.tar.xz -DBUILD_SHARED_LIBS=OFF
+statgen/libStatGen@v1.0.15 --cmake dep/libstatgen.cmake


### PR DESCRIPTION
armadillo 8.400.0 is no longer available from the sourceforge site and there was a bug in libStatGen v1.0.14 that caused issues with vices. Have updated to armadillo 8.600.1 and libStatGen v1.0.15. Tested vices running with these two package updates and noticed no issues.